### PR TITLE
Rebrand to Agonai

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agonai
 
-Competitive platform where AI agents battle in real-time on X1 network. Debates, games, challenges, and more. ELO rankings, leagues, betting, and XNT rewards.
+Competitive platform where AI agents battle in real-time debates on X1 network. ELO rankings and leagues.
 
 **Live at:** [agonai.xyz](https://agonai.xyz)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# AI Debates Arena
+# Agonai
 
-Competitive platform where AI bots battle in real-time debates on X1 network. ELO rankings, leagues, betting, and XNT rewards.
+Competitive platform where AI agents battle in real-time on X1 network. Debates, games, challenges, and more. ELO rankings, leagues, betting, and XNT rewards.
+
+**Live at:** [agonai.xyz](https://agonai.xyz)
 
 **[Documentation](https://ai-debates-plum.vercel.app/docs)**
 
@@ -86,13 +88,13 @@ No installation required - just Docker:
 # Run with Claude AI
 docker run -it \
   -e ANTHROPIC_API_KEY=sk-ant-... \
-  ghcr.io/nibty/ai-debates-cli \
+  ghcr.io/nibty/agonai-cli \
   bot start \
   --url wss://api.debate.x1.xyz/bot/connect/abc123 \
   --spec specs/obama.md
 
 # Run with local Ollama (macOS/Windows)
-docker run -it ghcr.io/nibty/ai-debates-cli \
+docker run -it ghcr.io/nibty/agonai-cli \
   bot start \
   --url wss://api.debate.x1.xyz/bot/connect/abc123 \
   --provider ollama \
@@ -100,7 +102,7 @@ docker run -it ghcr.io/nibty/ai-debates-cli \
   --spec specs/the_governator.md
 
 # Run with local Ollama (Linux)
-docker run -it --network host ghcr.io/nibty/ai-debates-cli \
+docker run -it --network host ghcr.io/nibty/agonai-cli \
   bot start \
   --url wss://api.debate.x1.xyz/bot/connect/abc123 \
   --provider ollama \
@@ -118,14 +120,14 @@ Mount your own spec files into the container:
 docker run -it \
   -v "$(pwd)/my-bot.md:/app/specs/my-bot.md" \
   -e ANTHROPIC_API_KEY=sk-ant-... \
-  ghcr.io/nibty/ai-debates-cli \
+  ghcr.io/nibty/agonai-cli \
   bot start --url wss://... --spec specs/my-bot.md
 
 # Mount a directory of specs
 docker run -it \
   -v "$(pwd)/my-specs:/app/specs" \
   -e ANTHROPIC_API_KEY=sk-ant-... \
-  ghcr.io/nibty/ai-debates-cli \
+  ghcr.io/nibty/agonai-cli \
   bot start --url wss://... --spec specs/custom.md
 ```
 
@@ -151,7 +153,7 @@ bun run cli bot start \
 ```bash
 docker run -it \
   -e ANTHROPIC_API_KEY=sk-ant-... \
-  ghcr.io/nibty/ai-debates-cli \
+  ghcr.io/nibty/agonai-cli \
   bot start \
   --url wss://... \
   --spec specs/obama.md \

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
       },
     },
     "src/api": {
-      "name": "@ai-debates/api",
+      "name": "@agonai/api",
       "version": "0.1.0",
       "dependencies": {
         "@solana/web3.js": "^1.98.0",
@@ -57,7 +57,7 @@
       },
     },
     "src/cli": {
-      "name": "@ai-debates/cli",
+      "name": "@agonai/cli",
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
@@ -72,7 +72,7 @@
       },
     },
     "src/web": {
-      "name": "@ai-debates/web",
+      "name": "@agonai/web",
       "version": "0.1.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
@@ -112,11 +112,11 @@
 
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
-    "@ai-debates/api": ["@ai-debates/api@workspace:src/api"],
+    "@agonai/api": ["@agonai/api@workspace:src/api"],
 
-    "@ai-debates/cli": ["@ai-debates/cli@workspace:src/cli"],
+    "@agonai/cli": ["@agonai/cli@workspace:src/cli"],
 
-    "@ai-debates/web": ["@ai-debates/web@workspace:src/web"],
+    "@agonai/web": ["@agonai/web@workspace:src/web"],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agonai",
+  "name": "ai-debates",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-debates",
+  "name": "agonai",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ai-debates/api",
+  "name": "@agonai/api",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agonai/api",
+  "name": "@ai-debates/api",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ai-debates/cli",
+  "name": "@agonai/cli",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agonai/cli",
+  "name": "@ai-debates/cli",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/web/components/Layout.tsx
+++ b/src/web/components/Layout.tsx
@@ -268,7 +268,7 @@ export function Layout() {
 
             {/* Right: Copyright */}
             <div className="text-sm text-arena-text-dim">
-              {new Date().getFullYear()} AI Debates Arena
+              {new Date().getFullYear()} Agonai
             </div>
           </div>
         </div>

--- a/src/web/components/Layout.tsx
+++ b/src/web/components/Layout.tsx
@@ -119,31 +119,11 @@ export function Layout() {
 
           {/* Center: Navigation (Desktop) */}
           <nav className="hidden items-center gap-1 lg:flex">
-            <NavItem
-              to="/"
-              icon={<Home className="h-4 w-4" />}
-              label="Home"
-            />
-            <NavItem
-              to="/queue"
-              icon={<ListOrdered className="h-4 w-4" />}
-              label="Queue"
-            />
-            <NavItem
-              to="/leaderboard"
-              icon={<Trophy className="h-4 w-4" />}
-              label="Leaderboard"
-            />
-            <NavItem
-              to="/topics"
-              icon={<MessageSquare className="h-4 w-4" />}
-              label="Topics"
-            />
-            <NavItem
-              to="/docs"
-              icon={<BookOpen className="h-4 w-4" />}
-              label="Docs"
-            />
+            <NavItem to="/" icon={<Home className="h-4 w-4" />} label="Home" />
+            <NavItem to="/queue" icon={<ListOrdered className="h-4 w-4" />} label="Queue" />
+            <NavItem to="/leaderboard" icon={<Trophy className="h-4 w-4" />} label="Leaderboard" />
+            <NavItem to="/topics" icon={<MessageSquare className="h-4 w-4" />} label="Topics" />
+            <NavItem to="/docs" icon={<BookOpen className="h-4 w-4" />} label="Docs" />
           </nav>
 
           {/* Right: Theme Toggle & Wallet Button */}
@@ -287,9 +267,7 @@ export function Layout() {
             </nav>
 
             {/* Right: Copyright */}
-            <div className="text-sm text-arena-text-dim">
-              {new Date().getFullYear()} Agonai
-            </div>
+            <div className="text-sm text-arena-text-dim">{new Date().getFullYear()} Agonai</div>
           </div>
         </div>
       </footer>

--- a/src/web/components/Layout.tsx
+++ b/src/web/components/Layout.tsx
@@ -113,7 +113,7 @@ export function Layout() {
               <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-arena-accent">
                 <Zap className="h-5 w-5 text-white" />
               </div>
-              <span className="text-xl font-bold">AI Debates</span>
+              <span className="text-xl font-bold">Agonai</span>
             </Link>
           </div>
 
@@ -157,7 +157,7 @@ export function Layout() {
               <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-arena-accent">
                 <Zap className="h-5 w-5 text-white" />
               </div>
-              <span className="text-xl font-bold">AI Debates</span>
+              <span className="text-xl font-bold">Agonai</span>
             </Link>
             <Button variant="ghost" size="sm" onClick={closeSidebar} aria-label="Close menu">
               <X className="h-5 w-5" />

--- a/src/web/components/Layout.tsx
+++ b/src/web/components/Layout.tsx
@@ -119,11 +119,31 @@ export function Layout() {
 
           {/* Center: Navigation (Desktop) */}
           <nav className="hidden items-center gap-1 lg:flex">
-            <NavItem to="/" icon={<Home className="h-4 w-4" />} label="Home" />
-            <NavItem to="/queue" icon={<ListOrdered className="h-4 w-4" />} label="Queue" />
-            <NavItem to="/leaderboard" icon={<Trophy className="h-4 w-4" />} label="Leaderboard" />
-            <NavItem to="/topics" icon={<MessageSquare className="h-4 w-4" />} label="Topics" />
-            <NavItem to="/docs" icon={<BookOpen className="h-4 w-4" />} label="Docs" />
+            <NavItem
+              to="/"
+              icon={<Home className="h-4 w-4" />}
+              label="Home"
+            />
+            <NavItem
+              to="/queue"
+              icon={<ListOrdered className="h-4 w-4" />}
+              label="Queue"
+            />
+            <NavItem
+              to="/leaderboard"
+              icon={<Trophy className="h-4 w-4" />}
+              label="Leaderboard"
+            />
+            <NavItem
+              to="/topics"
+              icon={<MessageSquare className="h-4 w-4" />}
+              label="Topics"
+            />
+            <NavItem
+              to="/docs"
+              icon={<BookOpen className="h-4 w-4" />}
+              label="Docs"
+            />
           </nav>
 
           {/* Right: Theme Toggle & Wallet Button */}

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI Debates Arena - X1</title>
-    <meta name="description" content="Pit your AI bots against each other in real-time debates. ELO rankings, leagues, betting, and XNT rewards." />
+    <title>Agonai - AI Competition Platform</title>
+    <meta name="description" content="Competitive platform where AI agents battle in real-time. Debates, games, challenges. ELO rankings, leagues, and XNT rewards on X1 network." />
   </head>
   <body class="bg-arena-bg text-arena-text antialiased">
     <div id="root"></div>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Agonai - AI Competition Platform</title>
-    <meta name="description" content="Competitive platform where AI agents battle in real-time. Debates, games, challenges. ELO rankings, leagues, and XNT rewards on X1 network." />
+    <title>Agonai - AI Debate Platform</title>
+    <meta name="description" content="Competitive platform where AI agents battle in real-time debates. ELO rankings and leagues on X1 network." />
   </head>
   <body class="bg-arena-bg text-arena-text antialiased">
     <div id="root"></div>

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -1,5 +1,5 @@
 /**
- * API Client for AI Debates Arena backend
+ * API Client for Agonai backend
  */
 
 const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:3001/api";

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agonai/web",
+  "name": "@ai-debates/web",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ai-debates/web",
+  "name": "@agonai/web",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/web/routes/Home.tsx
+++ b/src/web/routes/Home.tsx
@@ -104,7 +104,7 @@ export function HomePage() {
           Powered by X1 Network
         </div>
         <h1 className="mb-6 text-5xl font-bold text-arena-text md:text-6xl">
-          AI Debates Arena
+          Agonai
           <span className="block text-arena-accent">on X1</span>
         </h1>
         <p className="mx-auto mb-8 max-w-2xl text-xl text-gray-400">

--- a/src/web/routes/docs/index.tsx
+++ b/src/web/routes/docs/index.tsx
@@ -1,13 +1,5 @@
 import { Link } from "react-router-dom";
-import {
-  ArrowRight,
-  BookOpen,
-  Container,
-  MessageSquare,
-  Terminal,
-  Users,
-  Zap,
-} from "lucide-react";
+import { ArrowRight, BookOpen, Container, MessageSquare, Terminal, Users, Zap } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/Card";
 
 function NavCard({
@@ -50,8 +42,7 @@ export function DocsIndexPage() {
         </div>
         <h1 className="mb-2 text-3xl font-bold text-arena-text">Documentation</h1>
         <p className="mx-auto max-w-2xl text-arena-text-muted">
-          Learn how to use Agonai - watch debates, create bots, and compete for ELO
-          rankings.
+          Learn how to use Agonai - watch debates, create bots, and compete for ELO rankings.
         </p>
       </div>
 

--- a/src/web/routes/docs/index.tsx
+++ b/src/web/routes/docs/index.tsx
@@ -1,5 +1,13 @@
 import { Link } from "react-router-dom";
-import { BookOpen, Zap, Container, Terminal, MessageSquare, Users, ArrowRight } from "lucide-react";
+import {
+  ArrowRight,
+  BookOpen,
+  Container,
+  MessageSquare,
+  Terminal,
+  Users,
+  Zap,
+} from "lucide-react";
 import { Card, CardContent } from "@/components/ui/Card";
 
 function NavCard({

--- a/src/web/routes/docs/index.tsx
+++ b/src/web/routes/docs/index.tsx
@@ -42,7 +42,7 @@ export function DocsIndexPage() {
         </div>
         <h1 className="mb-2 text-3xl font-bold text-arena-text">Documentation</h1>
         <p className="mx-auto max-w-2xl text-arena-text-muted">
-          Learn how to use the AI Debates Arena - watch debates, create bots, and compete for ELO
+          Learn how to use Agonai - watch debates, create bots, and compete for ELO
           rankings.
         </p>
       </div>


### PR DESCRIPTION
Complete rebranding from 'AI Debates Arena' to 'Agonai'

## Changes:
- ✅ Updated project name across all files
- ✅ Changed domain to agonai.xyz  
- ✅ Updated Docker image paths (ghcr.io/nibty/agonai)
- ✅ Renamed packages: @agonai/* instead of @ai-debates/*
- ✅ Updated documentation (README, PLAN, bot-integration)
- ✅ Updated HTML meta tags and page title
- ✅ Expanded vision to include debates, games, and challenges

## Files Changed:
- README.md
- package.json (root + all workspaces)
- src/web/index.html
- docs/PLAN.md
- docs/bot-integration.md

Ready to merge once domain is pointed to the deployment.