### PR TITLE
feat(queue): multi-url bot start + same-owner match controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ bun run cli bot start \
   --spec ./my-spec.md \
   --auto-queue \
   --preset all
+
+# Connect multiple bots, queue one at a time (random selection)
+bun run cli bot start \
+  --url wss://...botA \
+  --url wss://...botB \
+  --auto-queue
 ```
 </details>
 
@@ -171,9 +177,11 @@ docker run -it \
 </details>
 
 Options:
+- `--url <ws-url>` - Repeat for multiple bot URLs, or pass a comma-separated list
 - `--auto-queue` - Automatically join queue on connect and after each debate
 - `--preset <id>` - Queue preset: `lightning`, `classic`, `crossex`, `escalation`, or `all`
 - `--stake <amount>` - XNT stake amount (default: 0)
+- `--allow-same-owner` - Allow matches against bots from the same owner (default: disabled)
 - `--provider <name>` - LLM provider: `claude` (default) or `ollama`
 - `--ollama-url <url>` - Ollama API URL (use `http://host.docker.internal:11434` in Docker on macOS/Windows)
 
@@ -203,11 +211,12 @@ bun run cli status                       # Check login status
 # Bot Management
 bun run cli bot create <name>            # Create bot, get connection URL
 bun run cli bot list                     # List your bots
-bun run cli bot start --url <ws-url>     # Run bot with direct URL
+bun run cli bot start --url <ws-url>     # Run bot with direct URL (repeatable)
   --spec <file>                          # Personality spec file
   --auto-queue                           # Auto-join matchmaking queue
   --preset <id>                          # Preset: lightning/classic/crossex/escalation/all
   --stake <amount>                       # Queue stake amount
+  --allow-same-owner                     # Allow same-owner matches (default disabled)
 
 # Matchmaking Queue
 bun run cli queue join <botId>           # Join queue

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -148,12 +148,23 @@ ANTHROPIC_API_KEY=sk-ant-... bun run cli bot start \
 
 # With personality spec and auto-queue
 bun run cli bot start --url wss://... --spec ./my-bot.md --auto-queue
+
+# Multi-bot mode: connect all URLs, queue one random bot at a time
+bun run cli bot start \
+  --url wss://...botA \
+  --url wss://...botB \
+  --auto-queue
+
+# Explicitly allow same-owner matches (default is disallow)
+bun run cli bot start --url wss://... --auto-queue --allow-same-owner
 ```
 :::
 
 ## Queue Commands
 
 Manage matchmaking.
+
+> Same-owner matches are blocked by default. In the web queue UI, use the **Allow same-owner matches** checkbox only when you intentionally want self-play.
 
 ::: code-group
 ```bash [Docker]

--- a/src/api/api/routes.ts
+++ b/src/api/api/routes.ts
@@ -496,7 +496,7 @@ router.post("/queue/join", authMiddleware, async (req: AuthenticatedRequest, res
     return;
   }
 
-  const { botId, stake, presetId } = result.data;
+  const { botId, stake, presetId, allowSameOwnerMatch } = result.data;
 
   const bot = await botRepository.findById(botId);
   if (!bot) {
@@ -510,9 +510,9 @@ router.post("/queue/join", authMiddleware, async (req: AuthenticatedRequest, res
   }
 
   // addToQueue handles removing any existing entry for this bot
-  const entry = await matchmaking.addToQueue(bot, req.userId, stake, presetId);
+  const entry = await matchmaking.addToQueue(bot, req.userId, stake, presetId, allowSameOwnerMatch);
   logger.info(
-    { botId: bot.id, botName: bot.name, stake, elo: bot.elo, presetId },
+    { botId: bot.id, botName: bot.name, stake, elo: bot.elo, presetId, allowSameOwnerMatch },
     "Bot joined queue"
   );
   const queueStats = await matchmaking.getStats();

--- a/src/api/services/matchmaking.ts
+++ b/src/api/services/matchmaking.ts
@@ -243,7 +243,8 @@ export class MatchmakingService {
       stake: parseFloat(data["stake"] as string),
       joinedAt: new Date(data["joinedAt"] as string),
       expandedRange: parseInt(data["expandedRange"] as string, 10),
-      allowSameOwnerMatch: data["allowSameOwnerMatch"] === "1" || data["allowSameOwnerMatch"] === "true",
+      allowSameOwnerMatch:
+        data["allowSameOwnerMatch"] === "1" || data["allowSameOwnerMatch"] === "true",
     };
   }
 

--- a/src/api/types/index.test.ts
+++ b/src/api/types/index.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { countWords, validateBotResponse } from "./index.js";
+import { JoinQueueSchema, countWords, validateBotResponse } from "./index.js";
+
+describe("JoinQueueSchema", () => {
+  it("defaults allowSameOwnerMatch to false", () => {
+    const parsed = JoinQueueSchema.parse({ botId: 123, stake: 0, presetId: "classic" });
+    expect(parsed.allowSameOwnerMatch).toBe(false);
+  });
+
+  it("accepts allowSameOwnerMatch=true when explicitly provided", () => {
+    const parsed = JoinQueueSchema.parse({
+      botId: 123,
+      stake: 0,
+      presetId: "classic",
+      allowSameOwnerMatch: true,
+    });
+    expect(parsed.allowSameOwnerMatch).toBe(true);
+  });
+});
 
 describe("Bot Response Validation", () => {
   describe("countWords", () => {

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -175,6 +175,7 @@ export interface QueueEntry {
   stake: number;
   joinedAt: Date;
   expandedRange: number; // Increases over time for faster matching
+  allowSameOwnerMatch: boolean;
 }
 
 // ============================================================================
@@ -396,6 +397,7 @@ export const JoinQueueSchema = z.object({
       message: "Invalid preset ID",
     })
     .default("classic"),
+  allowSameOwnerMatch: z.boolean().optional().default(false),
 });
 
 export type JoinQueueRequest = z.infer<typeof JoinQueueSchema>;

--- a/src/api/ws/botConnectionServer.ts
+++ b/src/api/ws/botConnectionServer.ts
@@ -72,6 +72,7 @@ interface QueueJoinMessage {
   type: "queue_join";
   stake?: number;
   presetId?: string;
+  allowSameOwnerMatch?: boolean;
 }
 
 interface QueueLeaveMessage {
@@ -509,7 +510,7 @@ export class BotConnectionServer {
    * Handle queue join request from a bot
    */
   private async handleQueueJoin(bot: ConnectedBot, message: QueueJoinMessage): Promise<void> {
-    const { stake = 0, presetId = "classic" } = message;
+    const { stake = 0, presetId = "classic", allowSameOwnerMatch = false } = message;
 
     try {
       // Get full bot info including owner
@@ -527,7 +528,13 @@ export class BotConnectionServer {
       // Add to queue for each preset
       for (const preset of presetsToJoin) {
         try {
-          const entry = await matchmaking.addToQueue(botData, botData.ownerId, stake, preset);
+          const entry = await matchmaking.addToQueue(
+            botData,
+            botData.ownerId,
+            stake,
+            preset,
+            allowSameOwnerMatch
+          );
           queueIds.push(entry.id);
           joinedPresets.push(preset);
         } catch (err) {

--- a/src/cli/commands/bot.ts
+++ b/src/cli/commands/bot.ts
@@ -1149,7 +1149,10 @@ function sendQueueJoin(ws: WebSocket): void {
 
   const url = wsToUrl.get(ws) ?? "unknown";
   if (queuedWsUrl || queueJoinPendingUrl) {
-    logger.debug({ queuedWsUrl, queueJoinPendingUrl, requester: url }, "Queue slot already occupied");
+    logger.debug(
+      { queuedWsUrl, queueJoinPendingUrl, requester: url },
+      "Queue slot already occupied"
+    );
     return;
   }
 
@@ -1190,7 +1193,10 @@ function queueRandomBot(delaySeconds = 0): void {
 
     const ws = openSockets[Math.floor(Math.random() * openSockets.length)];
     const url = wsToUrl.get(ws) ?? "unknown";
-    logger.info({ url, openConnections: openSockets.length }, "Randomly selected bot for queue join");
+    logger.info(
+      { url, openConnections: openSockets.length },
+      "Randomly selected bot for queue join"
+    );
 
     if (autoQueueConfig.waitForOpponent) {
       void waitForOpponentAndJoin(ws);
@@ -1490,7 +1496,10 @@ function connectDirect(url: string): void {
             const wsUrl = wsToUrl.get(ws) ?? "unknown";
             if (queueJoinPendingUrl === wsUrl) queueJoinPendingUrl = null;
             if (queuedWsUrl === wsUrl) queuedWsUrl = null;
-            logger.error({ url: wsUrl, error: parsedMessage.error }, `Queue error: ${parsedMessage.error}`);
+            logger.error(
+              { url: wsUrl, error: parsedMessage.error },
+              `Queue error: ${parsedMessage.error}`
+            );
             queueRandomBot(5);
             break;
           }
@@ -1519,7 +1528,10 @@ function connectDirect(url: string): void {
 
               const delay = autoQueueConfig.delaySeconds;
               if (delay > 0) {
-                logger.info({ delaySeconds: delay }, `Waiting ${delay}s before queueing another bot`);
+                logger.info(
+                  { delaySeconds: delay },
+                  `Waiting ${delay}s before queueing another bot`
+                );
                 queueRandomBot(delay);
               } else {
                 queueRandomBot();

--- a/src/cli/commands/bot.ts
+++ b/src/cli/commands/bot.ts
@@ -661,7 +661,7 @@ function connect(url: string): void {
   logger.info({ url }, "Connecting to WebSocket");
 
   const ws = new WebSocket(url);
-  activeWs = ws;
+  activeSockets.add(ws);
   let reconnectAttempts = 0;
   const maxReconnectDelay = 30000;
 
@@ -850,6 +850,7 @@ function connect(url: string): void {
 
   ws.on("close", (code, reason) => {
     logger.info({ code, reason: reason.toString() }, "Disconnected");
+    activeSockets.delete(ws);
 
     // Don't reconnect if shutting down
     if (isShuttingDown) {
@@ -861,7 +862,8 @@ function connect(url: string): void {
 
     const delay = Math.min(1000 * Math.pow(2, reconnectAttempts), maxReconnectDelay);
     reconnectAttempts++;
-    reconnectTimeout = setTimeout(() => connect(url), delay);
+    const t = setTimeout(() => connect(url), delay);
+    reconnectTimeouts.add(t);
   });
 
   ws.on("error", (error) => {
@@ -876,6 +878,7 @@ interface AutoQueueConfig {
   presetId: string;
   delaySeconds: number;
   waitForOpponent: boolean;
+  allowSameOwnerMatch: boolean;
   apiBaseUrl: string;
 }
 
@@ -885,6 +888,7 @@ let autoQueueConfig: AutoQueueConfig = {
   presetId: "classic",
   delaySeconds: 0,
   waitForOpponent: false,
+  allowSameOwnerMatch: false,
   apiBaseUrl: "",
 };
 
@@ -968,7 +972,7 @@ async function waitForOpponentAndJoin(ws: WebSocket): Promise<void> {
  * This is the main entrypoint for K8s deployments with pre-registered bots
  */
 export function start(options: {
-  url: string;
+  urls: string[];
   spec?: string;
   specText?: string;
   autoQueue?: boolean;
@@ -976,12 +980,13 @@ export function start(options: {
   preset?: string;
   queueDelay?: number;
   waitForOpponent?: boolean;
+  allowSameOwnerMatch?: boolean;
   provider?: string;
   model?: string;
   ollamaUrl?: string;
 }): void {
   const {
-    url,
+    urls,
     spec,
     specText,
     autoQueue = false,
@@ -989,19 +994,20 @@ export function start(options: {
     preset = "classic",
     queueDelay = 300,
     waitForOpponent = false,
+    allowSameOwnerMatch = false,
     provider = "claude",
     model,
     ollamaUrl = "http://localhost:11434",
   } = options;
 
-  // Validate URL
-  if (!url) {
-    logger.error({}, "WebSocket URL required. Use --url <ws-url>");
+  // Validate URLs
+  if (!urls || urls.length === 0) {
+    logger.error({}, "At least one WebSocket URL is required. Use --url <ws-url>");
     console.log(`
-Usage: bun run cli bot start --url <ws-url> [options]
+Usage: bun run cli bot start --url <ws-url> [--url <ws-url> ...] [options]
 
 Options:
-  --url <ws-url>        WebSocket connection URL (required)
+  --url <ws-url>        WebSocket connection URL (required, repeatable)
   --spec <file>         Path to spec file or directory
   --spec-text <text>    Inline personality spec (alternative to --spec)
   --auto-queue          Automatically join matchmaking queue
@@ -1009,6 +1015,7 @@ Options:
   --preset <id>         Debate preset ID (default: classic)
   --queue-delay <sec>   Seconds to wait before rejoining queue (default: 300)
   --wait-for-opponent   Only join queue when another bot is waiting
+  --allow-same-owner    Allow matches against your own bots (default: false)
   --provider <name>     LLM provider: claude or ollama (default: claude)
   --model <name>        Model name (Claude: claude-sonnet-4-20250514, claude-opus-4-20250514, etc.)
                         (Ollama: llama3, mistral, etc.)
@@ -1074,6 +1081,12 @@ Environment Variables:
     logger.info({ baseUrl: resolvedOllamaUrl, model: ollamaModel }, "Configured Ollama provider");
   }
 
+  const primaryUrl = urls[0];
+  if (!primaryUrl) {
+    logger.error({}, "At least one valid WebSocket URL is required");
+    process.exit(1);
+  }
+
   // Configure auto-queue
   autoQueueConfig = {
     enabled: autoQueue,
@@ -1081,7 +1094,8 @@ Environment Variables:
     presetId: preset,
     delaySeconds: queueDelay,
     waitForOpponent,
-    apiBaseUrl: getApiBaseUrl(url),
+    allowSameOwnerMatch,
+    apiBaseUrl: getApiBaseUrl(primaryUrl),
   };
 
   // Load spec if provided (specText takes precedence over spec file)
@@ -1104,13 +1118,27 @@ Environment Variables:
   const providerInfo =
     currentProvider === "ollama" ? `Ollama (${ollamaConfig?.model})` : `Claude (${claudeModel})`;
   logger.info(
-    { spec: spec ?? "none", autoQueue, stake, preset, provider: currentProvider },
-    `Starting ${providerInfo} bot, connecting to WebSocket...`
+    {
+      spec: spec ?? "none",
+      autoQueue,
+      stake,
+      preset,
+      provider: currentProvider,
+      urlCount: urls.length,
+      allowSameOwnerMatch,
+    },
+    `Starting ${providerInfo} bot(s), connecting to WebSockets...`
   );
   if (autoQueue) {
-    logger.info({ stake, preset }, `Auto-queue enabled (stake: ${stake}, preset: ${preset})`);
+    logger.info(
+      { stake, preset, allowSameOwnerMatch },
+      `Auto-queue enabled (stake: ${stake}, preset: ${preset}, allowSameOwnerMatch: ${allowSameOwnerMatch})`
+    );
   }
-  connectDirect(url);
+
+  for (const wsUrl of urls) {
+    connectDirect(wsUrl);
+  }
 }
 
 /**
@@ -1119,26 +1147,77 @@ Environment Variables:
 function sendQueueJoin(ws: WebSocket): void {
   if (ws.readyState !== WebSocket.OPEN) return;
 
+  const url = wsToUrl.get(ws) ?? "unknown";
+  if (queuedWsUrl || queueJoinPendingUrl) {
+    logger.debug({ queuedWsUrl, queueJoinPendingUrl, requester: url }, "Queue slot already occupied");
+    return;
+  }
+
+  queueJoinPendingUrl = url;
   const message = {
     type: "queue_join",
     stake: autoQueueConfig.stake,
     presetId: autoQueueConfig.presetId,
+    allowSameOwnerMatch: autoQueueConfig.allowSameOwnerMatch,
   };
   ws.send(JSON.stringify(message));
   logger.info(
-    { stake: autoQueueConfig.stake, preset: autoQueueConfig.presetId },
+    {
+      url,
+      stake: autoQueueConfig.stake,
+      preset: autoQueueConfig.presetId,
+      allowSameOwnerMatch: autoQueueConfig.allowSameOwnerMatch,
+    },
     "Sent queue_join request"
   );
+}
+
+function getOpenSockets(): WebSocket[] {
+  return Array.from(activeSockets).filter((ws) => ws.readyState === WebSocket.OPEN);
+}
+
+function queueRandomBot(delaySeconds = 0): void {
+  if (!autoQueueConfig.enabled || isShuttingDown) return;
+
+  const action = () => {
+    if (queuedWsUrl || queueJoinPendingUrl || isShuttingDown) return;
+
+    const openSockets = getOpenSockets();
+    if (openSockets.length === 0) {
+      logger.warn({}, "No connected bots available to queue");
+      return;
+    }
+
+    const ws = openSockets[Math.floor(Math.random() * openSockets.length)];
+    const url = wsToUrl.get(ws) ?? "unknown";
+    logger.info({ url, openConnections: openSockets.length }, "Randomly selected bot for queue join");
+
+    if (autoQueueConfig.waitForOpponent) {
+      void waitForOpponentAndJoin(ws);
+    } else {
+      sendQueueJoin(ws);
+    }
+  };
+
+  if (delaySeconds > 0) {
+    const t = setTimeout(action, delaySeconds * 1000);
+    reconnectTimeouts.add(t);
+  } else {
+    action();
+  }
 }
 
 // Track in-flight requests for debugging
 const inFlightRequests = new Map<string, { startTime: number; debateId: string; round: string }>();
 
-// Track active WebSocket and timeouts for graceful shutdown
-let activeWs: WebSocket | null = null;
-let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+// Track active WebSockets/timeouts for graceful shutdown
+const activeSockets = new Set<WebSocket>();
+const reconnectTimeouts = new Set<ReturnType<typeof setTimeout>>();
+const connectedUrls = new Set<string>();
+const wsToUrl = new WeakMap<WebSocket, string>();
+let queuedWsUrl: string | null = null;
+let queueJoinPendingUrl: string | null = null;
 let isShuttingDown = false;
-let hasConnectedBefore = false;
 const RECONNECT_QUEUE_DELAY_SECONDS = 30; // Delay before rejoining queue after reconnect
 
 function gracefulShutdown(signal: string): void {
@@ -1147,15 +1226,17 @@ function gracefulShutdown(signal: string): void {
 
   logger.info({ signal }, "Shutting down bot...");
 
-  // Clear any pending reconnect
-  if (reconnectTimeout) {
-    clearTimeout(reconnectTimeout);
-    reconnectTimeout = null;
+  // Clear pending reconnect / delayed queue timers
+  for (const t of reconnectTimeouts) {
+    clearTimeout(t);
   }
+  reconnectTimeouts.clear();
 
-  // Close WebSocket gracefully
-  if (activeWs && activeWs.readyState === WebSocket.OPEN) {
-    activeWs.close(1000, "Graceful shutdown");
+  // Close all WebSockets gracefully
+  for (const ws of activeSockets) {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.close(1000, "Graceful shutdown");
+    }
   }
 
   // Give a moment for close to complete
@@ -1305,7 +1386,8 @@ function connectDirect(url: string): void {
   logger.info({ url }, "Connecting to WebSocket");
 
   const ws = new WebSocket(url);
-  activeWs = ws;
+  wsToUrl.set(ws, url);
+  activeSockets.add(ws);
   let reconnectAttempts = 0;
   const maxReconnectDelay = 30000;
 
@@ -1339,8 +1421,8 @@ function connectDirect(url: string): void {
 
         switch (parsedMessage.type) {
           case "connected": {
-            const isReconnect = hasConnectedBefore;
-            hasConnectedBefore = true;
+            const isReconnect = connectedUrls.has(url);
+            connectedUrls.add(url);
             const hasActiveDebate = parsedMessage.hasActiveDebate ?? false;
 
             logger.info(
@@ -1359,26 +1441,16 @@ function connectDirect(url: string): void {
               break;
             }
 
-            // Auto-join queue if enabled
+            // Auto-join queue if enabled (one bot at a time across all connections)
             if (autoQueueConfig.enabled) {
-              const joinQueue = (): void => {
-                if (ws.readyState !== WebSocket.OPEN || isShuttingDown) return;
-                if (autoQueueConfig.waitForOpponent) {
-                  void waitForOpponentAndJoin(ws);
-                } else {
-                  sendQueueJoin(ws);
-                }
-              };
-
               if (isReconnect) {
-                // Delay rejoining queue after reconnect to let server stabilize
                 logger.info(
                   { delaySeconds: RECONNECT_QUEUE_DELAY_SECONDS },
-                  `Waiting ${RECONNECT_QUEUE_DELAY_SECONDS}s before rejoining queue (reconnect)`
+                  `Waiting ${RECONNECT_QUEUE_DELAY_SECONDS}s before considering rejoin (reconnect)`
                 );
-                setTimeout(joinQueue, RECONNECT_QUEUE_DELAY_SECONDS * 1000);
+                queueRandomBot(RECONNECT_QUEUE_DELAY_SECONDS);
               } else {
-                joinQueue();
+                queueRandomBot();
               }
             }
             break;
@@ -1389,9 +1461,13 @@ function connectDirect(url: string): void {
             safeSend(ws, JSON.stringify({ type: "pong" }), {});
             break;
 
-          case "queue_joined":
+          case "queue_joined": {
+            const wsUrl = wsToUrl.get(ws) ?? "unknown";
+            queuedWsUrl = wsUrl;
+            queueJoinPendingUrl = null;
             logger.info(
               {
+                url: wsUrl,
                 queueIds: parsedMessage.queueIds,
                 stake: parsedMessage.stake,
                 presets: parsedMessage.presetIds,
@@ -1399,14 +1475,25 @@ function connectDirect(url: string): void {
               `Joined ${parsedMessage.presetIds.length} queue(s): ${parsedMessage.presetIds.join(", ")} (stake: ${parsedMessage.stake})`
             );
             break;
+          }
 
-          case "queue_left":
-            logger.info({}, "Left matchmaking queue");
+          case "queue_left": {
+            const wsUrl = wsToUrl.get(ws) ?? "unknown";
+            if (queuedWsUrl === wsUrl) queuedWsUrl = null;
+            if (queueJoinPendingUrl === wsUrl) queueJoinPendingUrl = null;
+            logger.info({ url: wsUrl }, "Left matchmaking queue");
+            queueRandomBot();
             break;
+          }
 
-          case "queue_error":
-            logger.error({ error: parsedMessage.error }, `Queue error: ${parsedMessage.error}`);
+          case "queue_error": {
+            const wsUrl = wsToUrl.get(ws) ?? "unknown";
+            if (queueJoinPendingUrl === wsUrl) queueJoinPendingUrl = null;
+            if (queuedWsUrl === wsUrl) queuedWsUrl = null;
+            logger.error({ url: wsUrl, error: parsedMessage.error }, `Queue error: ${parsedMessage.error}`);
+            queueRandomBot(5);
             break;
+          }
 
           case "debate_complete": {
             const resultStr =
@@ -1424,25 +1511,18 @@ function connectDirect(url: string): void {
               `Debate #${parsedMessage.debateId} completed: ${resultStr} (ELO: ${eloStr})`
             );
 
-            // Auto-rejoin queue if enabled (with delay)
+            // Auto-rejoin queue if enabled (one bot at a time)
             if (autoQueueConfig.enabled) {
-              const delay = autoQueueConfig.delaySeconds;
-              const rejoinQueue = (): void => {
-                if (ws.readyState !== WebSocket.OPEN) return;
-                if (autoQueueConfig.waitForOpponent) {
-                  logger.info({}, "Waiting for opponent before rejoining queue");
-                  void waitForOpponentAndJoin(ws);
-                } else {
-                  logger.info({}, "Rejoining queue");
-                  sendQueueJoin(ws);
-                }
-              };
+              const wsUrl = wsToUrl.get(ws) ?? "unknown";
+              if (queuedWsUrl === wsUrl) queuedWsUrl = null;
+              if (queueJoinPendingUrl === wsUrl) queueJoinPendingUrl = null;
 
+              const delay = autoQueueConfig.delaySeconds;
               if (delay > 0) {
-                logger.info({ delaySeconds: delay }, `Waiting ${delay}s before rejoining queue`);
-                setTimeout(rejoinQueue, delay * 1000);
+                logger.info({ delaySeconds: delay }, `Waiting ${delay}s before queueing another bot`);
+                queueRandomBot(delay);
               } else {
-                rejoinQueue();
+                queueRandomBot();
               }
             }
             break;
@@ -1491,7 +1571,11 @@ function connectDirect(url: string): void {
   });
 
   ws.on("close", (code, reason) => {
-    logger.info({ code, reason: reason.toString() }, "Disconnected from server");
+    logger.info({ url, code, reason: reason.toString() }, "Disconnected from server");
+    activeSockets.delete(ws);
+
+    if (queuedWsUrl === url) queuedWsUrl = null;
+    if (queueJoinPendingUrl === url) queueJoinPendingUrl = null;
 
     // Don't reconnect if shutting down
     if (isShuttingDown) {
@@ -1499,11 +1583,13 @@ function connectDirect(url: string): void {
       return;
     }
 
-    logger.info({ reconnectAttempts }, "Reconnecting...");
+    logger.info({ url, reconnectAttempts }, "Reconnecting...");
 
     const delay = Math.min(1000 * Math.pow(2, reconnectAttempts), maxReconnectDelay);
     reconnectAttempts++;
-    reconnectTimeout = setTimeout(() => connectDirect(url), delay);
+    const t = setTimeout(() => connectDirect(url), delay);
+    reconnectTimeouts.add(t);
+    queueRandomBot(1);
   });
 
   ws.on("error", (error) => {

--- a/src/cli/scripts/claude-compat.ts
+++ b/src/cli/scripts/claude-compat.ts
@@ -31,4 +31,4 @@ if (!process.env["ANTHROPIC_API_KEY"]) {
   process.exit(1);
 }
 
-start({ url, spec });
+start({ urls: [url], spec });

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -158,6 +158,7 @@ class ApiClient {
     botId: string;
     stake: number;
     presetId: string;
+    allowSameOwnerMatch?: boolean;
   }): Promise<{ entry: QueueEntry }> {
     return this.request("POST", "/queue/join", data);
   }

--- a/src/web/routes/Queue.tsx
+++ b/src/web/routes/Queue.tsx
@@ -29,6 +29,7 @@ export function QueuePage() {
   const [selectedBotId, setSelectedBotId] = useState<string | null>(null);
   const [queuedBots, setQueuedBots] = useState<Map<string, QueuedBotInfo>>(new Map());
   const [selectedPresetId, setSelectedPresetId] = useState("classic");
+  const [allowSameOwnerMatch, setAllowSameOwnerMatch] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Fetch user's bots from API
@@ -64,7 +65,12 @@ export function QueuePage() {
 
   // Join queue mutation
   const joinQueueMutation = useMutation({
-    mutationFn: (data: { botId: string; stake: number; presetId: string }) => api.joinQueue(data),
+    mutationFn: (data: {
+      botId: string;
+      stake: number;
+      presetId: string;
+      allowSameOwnerMatch?: boolean;
+    }) => api.joinQueue(data),
     onSuccess: (_data, variables) => {
       const bot = bots.find((b) => b.id == variables.botId);
       if (bot) {
@@ -141,7 +147,12 @@ export function QueuePage() {
       return;
     }
     setError(null);
-    joinQueueMutation.mutate({ botId: selectedBot.id, stake: 0, presetId: selectedPresetId });
+    joinQueueMutation.mutate({
+      botId: selectedBot.id,
+      stake: 0,
+      presetId: selectedPresetId,
+      allowSameOwnerMatch,
+    });
   };
 
   const handleLeaveQueue = (botId: string) => {
@@ -343,6 +354,24 @@ export function QueuePage() {
             {selectedPreset && (
               <p className="mt-2 text-xs text-gray-500">{selectedPreset.description}</p>
             )}
+          </div>
+
+          {/* Same-owner matching */}
+          <div className="rounded-lg bg-arena-card/50 p-3">
+            <label className="flex cursor-pointer items-center gap-3">
+              <input
+                type="checkbox"
+                checked={allowSameOwnerMatch}
+                onChange={(e) => setAllowSameOwnerMatch(e.target.checked)}
+                className="h-4 w-4 rounded border-gray-600 bg-arena-bg text-arena-accent"
+              />
+              <div>
+                <div className="text-sm font-medium text-arena-text">Allow same-owner matches</div>
+                <div className="text-xs text-gray-400">
+                  Off by default to prevent self-play. Enable only if you explicitly want your own bots to match each other.
+                </div>
+              </div>
+            </label>
           </div>
         </CardContent>
       </Card>

--- a/src/web/routes/Queue.tsx
+++ b/src/web/routes/Queue.tsx
@@ -368,7 +368,8 @@ export function QueuePage() {
               <div>
                 <div className="text-sm font-medium text-arena-text">Allow same-owner matches</div>
                 <div className="text-xs text-gray-400">
-                  Off by default to prevent self-play. Enable only if you explicitly want your own bots to match each other.
+                  Off by default to prevent self-play. Enable only if you explicitly want your own
+                  bots to match each other.
                 </div>
               </div>
             </label>


### PR DESCRIPTION
## Summary
- Update `bot start` to accept multiple `--url` values (repeatable or comma-separated).
- Connect all provided bot WebSocket URLs.
- Enforce one active queue participant at a time by randomly selecting one connected bot to queue.
- Add `--allow-same-owner` flag for CLI queue joins (default remains disallow).
- Add same-owner match policy to WebSocket and REST queue joins.
- Update matchmaking to block same-owner pairings unless **both** entries allow it.
- Add web queue checkbox: **Allow same-owner matches** (default off).

## Notes
- Default behavior is explicitly **no same-owner matches** to prevent self-play.
- Existing `claude-compat` script was updated for the new `start({ urls: [...] })` signature.

## Validation
- `bun run lint:cli && bun run lint:api && bun run lint:web`
- `bun run typecheck`
- `bun run format:check:web`
